### PR TITLE
Add compile instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,14 @@ macOS 10.11+ (tested on 10.12)
 * Toggle viewer background/shadows
 * Command line support
 
+## Compiling
+* **Requirements**: Xcode 9
+* Open `macfeh.xcodeproj` in Xcode.
+* Select the `macfeh Release` scheme from the pop up button in the top left.
+* Press the Run button, macfeh will compile and launch.
+* Once launched, ⌘+left click the macfeh icon in the dock.
+* Finder will show and select `macfeh.app` which you can now copy to your `/Applications/` folder or other.
+
 ## Command line
 To use macfeh from the command line, add 
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To use macfeh from the command line, add
 
 ```bash
 function macfeh() {
-	open -b "drabweb.macfeh" "$@"
+    open -b "drabweb.macfeh" "$@"
 }
 ```
 


### PR DESCRIPTION
Also replaced the tab in the rc example with four spaces.